### PR TITLE
Feature support for trigger based event handling

### DIFF
--- a/src/teltonika_handler/driver_one_card_id_event_handler.rs
+++ b/src/teltonika_handler/driver_one_card_id_event_handler.rs
@@ -22,6 +22,10 @@ impl TeltonikaEventHandler<TruckDriverCard, Error<CreateTruckDriverCardError>>
         vec![195, 196]
     }
 
+    fn get_trigger_event_id(&self) -> Option<u16> {
+        Some(187)
+    }
+
     async fn send_event(
         &self,
         event_data: &TruckDriverCard,
@@ -51,8 +55,16 @@ impl TeltonikaEventHandler<TruckDriverCard, Error<CreateTruckDriverCardError>>
         }
     }
 
-    fn process_event_data(&self, events: &Vec<&AVLEventIO>, _: i64) -> TruckDriverCard {
-        return driver_card_events_to_truck_driver_card(events);
+    fn process_event_data(
+        &self,
+        trigger_event_id: u16,
+        events: &Vec<&AVLEventIO>,
+        _: i64,
+    ) -> Option<TruckDriverCard> {
+        match trigger_event_id {
+            187 => Some(driver_card_events_to_truck_driver_card(events)),
+            _ => None,
+        }
     }
 }
 

--- a/src/teltonika_handler/driver_one_drive_state_event_handler.rs
+++ b/src/teltonika_handler/driver_one_drive_state_event_handler.rs
@@ -38,20 +38,25 @@ impl TeltonikaEventHandler<TruckDriveState, Error<CreateDriveStateError>>
         .await
     }
 
-    fn process_event_data(&self, events: &Vec<&AVLEventIO>, timestamp: i64) -> TruckDriveState {
+    fn process_event_data(
+        &self,
+        _trigger_event_id: u16,
+        events: &Vec<&AVLEventIO>,
+        timestamp: i64,
+    ) -> Option<TruckDriveState> {
         let driver_card = driver_card_events_to_truck_driver_card(events);
         let state_event = events
             .iter()
             .find(|event| event.id == 184)
             .expect("Driver one drive state event not found");
         let state = TruckDriveStateEnum::from_avl_event_io_value(&state_event.value);
-        return TruckDriveState {
+        Some(TruckDriveState {
             id: None,
             timestamp,
             state,
             driver_id: None,
             driver_card_id: Some(driver_card.id),
-        };
+        })
     }
 }
 

--- a/src/teltonika_handler/speed_event_handler.rs
+++ b/src/teltonika_handler/speed_event_handler.rs
@@ -32,13 +32,18 @@ impl TeltonikaEventHandler<TruckSpeed, Error<CreateTruckSpeedError>> for SpeedEv
         .await
     }
 
-    fn process_event_data(&self, events: &Vec<&AVLEventIO>, timestamp: i64) -> TruckSpeed {
+    fn process_event_data(
+        &self,
+        _trigger_event_id: u16,
+        events: &Vec<&AVLEventIO>,
+        timestamp: i64,
+    ) -> Option<TruckSpeed> {
         let event = events.first().expect("Received empty speed event");
-        TruckSpeed {
+        Some(TruckSpeed {
             id: None,
             speed: avl_event_io_value_to_u64(&event.value) as f32,
             timestamp,
-        }
+        })
     }
 }
 

--- a/src/teltonika_handler/teltonika_records_handler.rs
+++ b/src/teltonika_handler/teltonika_records_handler.rs
@@ -98,7 +98,12 @@ impl TeltonikaRecordsHandler {
     /// This method will iterate over the known event handlers and pass appropriate events to them.
     pub async fn handle_record(&self, record: &AVLRecord) {
         self.handle_record_location(record).await;
+        debug!("Record trigger event ID: {}", record.trigger_event_id);
         for handler in self.event_handlers.iter() {
+            let trigger_event_id = handler.get_trigger_event_id();
+            if trigger_event_id.is_some() && record.trigger_event_id != trigger_event_id.unwrap() {
+                continue;
+            }
             let events = handler
                 .get_event_ids()
                 .iter()
@@ -117,6 +122,7 @@ impl TeltonikaRecordsHandler {
             }
             handler
                 .handle_events(
+                    record.trigger_event_id,
                     events,
                     record.timestamp.timestamp(),
                     self.truck_id.clone(),

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,8 @@ pub mod avl_record_builder;
 
 #[cfg(test)]
 pub mod imei;
+#[cfg(test)]
+pub mod test_utils;
 
 /// Converts a hex string to a byte vector
 ///

--- a/src/utils/test_utils.rs
+++ b/src/utils/test_utils.rs
@@ -1,0 +1,134 @@
+use std::str::FromStr;
+
+use httpmock::{
+    Method::{GET, POST},
+    MockServer, Regex,
+};
+use nom_teltonika::AVLEventIO;
+use tempfile::tempdir;
+use uuid::Uuid;
+use vehicle_management_service::models::{PublicTruck, TruckDriverCard};
+
+use crate::teltonika_handler::teltonika_records_handler::TeltonikaRecordsHandler;
+
+/// Converts a driver card ID to two part events.
+///
+/// This function is a reverse implementation of what's described in [Teltonika Documentation](https://wiki.teltonika-gps.com/view/DriverID)
+/// where the driver card part is converted to a hexadecimal number from an ASCII-string.
+pub fn driver_card_id_to_two_part_events(driver_card_id: String) -> [AVLEventIO; 2] {
+    let (driver_card_id_msb, driver_card_id_lsb) = split_at_half(driver_card_id);
+    let driver_card_id_msb_dec = driver_card_part_to_dec(&driver_card_id_msb);
+    let driver_card_id_lsb_dec = driver_card_part_to_dec(&driver_card_id_lsb);
+    let driver_card_id_msb_event = AVLEventIO {
+        id: 195,
+        value: nom_teltonika::AVLEventIOValue::U64(driver_card_id_msb_dec),
+    };
+    let driver_card_id_lsb_event = AVLEventIO {
+        id: 196,
+        value: nom_teltonika::AVLEventIOValue::U64(driver_card_id_lsb_dec),
+    };
+    return [driver_card_id_msb_event, driver_card_id_lsb_event];
+}
+
+/// Splits a String at half
+pub fn split_at_half(string: String) -> (String, String) {
+    let half = string.len() / 2;
+    let (part_1, part_2) = string.split_at(half);
+
+    return (part_1.to_string(), part_2.to_string());
+}
+
+/// Converts a string to a hexadecimal string
+pub fn string_to_hex_string(string: &str) -> String {
+    return string
+        .as_bytes()
+        .iter()
+        .map(|byte| format!("{:02X}", byte))
+        .collect::<Vec<String>>()
+        .concat();
+}
+
+/// Reverses a string slice
+///
+/// This function is not used in the implementation at the moment but is kept in case it is needed later.
+#[allow(dead_code)]
+pub fn reverse_str(string: &str) -> String {
+    return string.chars().rev().collect::<String>();
+}
+
+/// Converts a driver card part to a decimal number
+pub fn driver_card_part_to_dec(driver_card_part: &str) -> u64 {
+    let driver_card_part_hex = string_to_hex_string(driver_card_part);
+
+    return u64::from_str_radix(&driver_card_part_hex, 16).unwrap();
+}
+
+/// Reads IMEI from the buffer
+///
+/// # Arguments
+/// * `buffer` - Buffer for reading data from socket
+///
+/// # Returns
+/// * `(bool, Option<String>)` - Whether the IMEI was successfully parsed and the IMEI itself as an `Option<String>`
+pub fn read_imei(buffer: &Vec<u8>) -> (bool, Option<String>) {
+    let result = nom_teltonika::parser::imei(&buffer);
+    match result {
+        Ok((_, imei)) => (true, Some(imei)),
+        Err(_) => (false, None),
+    }
+}
+
+/// Gets a TeltonikaRecordsHandler for testing
+///
+/// Uses a temporary directory for the cache
+pub fn get_teltonika_records_handler(truck_id: Option<String>) -> TeltonikaRecordsHandler {
+    let test_cache_dir = tempdir().unwrap();
+    let test_cache_path = test_cache_dir.path();
+
+    return TeltonikaRecordsHandler::new(test_cache_path, truck_id);
+}
+
+/// Starts a mock server for the Vehicle Management Service
+pub fn start_vehicle_management_mock() {
+    let mock_server = MockServer::start();
+    let mut server_address = String::from("http://");
+    server_address.push_str(mock_server.address().to_string().as_str());
+
+    std::env::set_var("API_BASE_URL", &server_address);
+    std::env::set_var("VEHICLE_MANAGEMENT_SERVICE_API_KEY", "API_KEY");
+
+    let _public_trucks_mock = mock_server.mock(|when, then| {
+        when.method(GET)
+            .path("/vehicle-management/v1/publicTrucks")
+            .header("X-API-KEY", "API_KEY");
+        then.status(200)
+            .header("Content-Type", "application/json")
+            .json_body_obj(&[PublicTruck {
+                id: Some(Uuid::from_str("3FFAF18C-69E4-4F8A-9179-9AEC5BC96E1C").unwrap()),
+                name: Some(String::from("1")),
+                plate_number: String::from("ABC-123"),
+                vin: String::from("W1T96302X10704959"),
+            }]);
+    });
+
+    let _create_truck_speed_mock = mock_server.mock(|when, then| {
+        when.method(POST)
+            .path_matches(Regex::new(r"/vehicle-management/v1/trucks/.{36}/speeds").unwrap())
+            .header("X-API-KEY", "API_KEY");
+        then.status(201);
+    });
+    let _create_truck_driver_card_mock = mock_server.mock(|when, then| {
+        when.method(POST)
+            .path_matches(Regex::new(r"/vehicle-management/v1/trucks/.{36}/driverCards").unwrap())
+            .header("X-API-KEY", "API_KEY");
+        then.status(201)
+            .header("Content-Type", "application/json")
+            .json_body_obj(&TruckDriverCard { id: String::new() });
+    });
+    let _create_truck_drive_state_mock = mock_server.mock(|when, then| {
+        when.method(POST)
+            .path_matches(Regex::new(r"/vehicle-management/v1/trucks/.{36}/driveState").unwrap())
+            .header("X-API-KEY", "API_KEY");
+        then.status(201);
+    });
+}


### PR DESCRIPTION
It's possible to configure Teltonika telematics devices to send so called eventual records and then the sent packet contains a field describing what event triggered the record.

This PR adds support for defining event handlers to only handle event if a given event has triggered the record